### PR TITLE
Add Shopware 6.6 compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,8 @@ The CronixAvantLink plugin integrates AvantLink’s **site-wide** and **order co
 
 - PHP 8.1 or higher  
 - Docker with Docker Desktop (recommended for local dev)  
-- Shopware 6.7.x (Tested on 6.7)  
+- Shopware 6.6.x or 6.7.x (tested on 6.7)
+  - Minimum Shopware version: 6.6.0.0
 - Composer  
 - Git  
 

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     },
     "keywords": ["shopware", "CronixAvantLink","plugin", "cronix", "automation", "linking","avaantlink","cronixweb"],
     "require": {
-        "shopware/core": "~6.7.0"
+        "shopware/core": "^6.6"
     },
     "extra": {
         "shopware-plugin-class": "CronixAvantLink\\CronixAvantLink",

--- a/src/Resources/config/config.xml
+++ b/src/Resources/config/config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/shopware/platform/trunk/src/Core/System/SystemConfig/Schema/config.xsd">
+        xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/shopware/platform/v6.6.0.0/src/Core/System/SystemConfig/Schema/config.xsd">
 
     <card>
         <title>AvantLink Settings</title>

--- a/src/Resources/config/plugin.xml
+++ b/src/Resources/config/plugin.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <plugin xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/shopware/shopware/v6.3.0/src/Core/Framework/Plugin/plugin.xsd">
+        xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/shopware/platform/v6.6.0.0/src/Core/Framework/Plugin/plugin.xsd">
     <meta>
         <name>Avantlink Integration By Cronix</name>
         <version>1.0.0</version>


### PR DESCRIPTION
## Summary
- allow installation on Shopware 6.6 by relaxing the core requirement
- align plugin metadata and config schema references with the Shopware 6.6 release
- document the minimum Shopware version in the README

## Testing
- composer validate